### PR TITLE
Deduplicate discovery certificates and add scheduled orphan cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,12 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pg: ["14", "16"]
     services:
       postgres:
-        image: postgres:16
+        image: postgres:${{ matrix.pg }}
         env: { POSTGRES_USER: pyadcs, POSTGRES_PASSWORD: pyadcs, POSTGRES_DB: pyadcs }
         ports: ['5432:5432']
         options: >-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Django project layout:
 
 ## Database & compatibility invariant
 
-PostgreSQL (12+). Tables live in the schema from `DATABASE_SCHEMA` (default `pyadcs`) and are pinned
+PostgreSQL (14+). Tables live in the schema from `DATABASE_SCHEMA` (default `pyadcs`) and are pinned
 via each model's `db_table`. **Do not** rename the app label `PyADCSConnector` or change the schema
 default — both are part of the upgrade contract and would break existing deployments.
 
@@ -51,3 +51,6 @@ default — both are part of the upgrade contract and would break existing deplo
 | `ADCS_ISSUE_POLLING_TIMEOUT` | `3000` | ms |
 | `GUNICORN_WORKERS` | CPU count | container |
 | `GUNICORN_THREADS` | `4` | container |
+| `CERTIFICATE_CLEANUP_ENABLED` | `true` | scheduled orphan-certificate sweep |
+| `CERTIFICATE_CLEANUP_INTERVAL_SECONDS` | `86400` | at most one sweep per interval across workers |
+| `CERTIFICATE_CLEANUP_BATCH_SIZE` | `1000` | rows per transaction; lock released between batches |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PyADCS `Connector` allows you to perform the following operations:
 
 ## Database requirements
 
-PyADCS `Connector` requires the PostgreSQL database version 12+.
+PyADCS `Connector` requires the **PostgreSQL 14+** database version.
 
 ## Docker container
 
@@ -45,3 +45,16 @@ PyADCS `Connector` is provided as a Docker container. Pull the image with `docke
 | `ADCS_ISSUE_POLLING_TIMEOUT`  | Timeout in milliseconds to wait for issued certificates            | ![](https://img.shields.io/badge/-NO-red.svg)      | `3000`        |
 | `GUNICORN_WORKERS`            | Number of Gunicorn worker processes                                | ![](https://img.shields.io/badge/-NO-red.svg)      | CPU count     |
 | `GUNICORN_THREADS`            | Number of threads per Gunicorn worker                              | ![](https://img.shields.io/badge/-NO-red.svg)      | `4`           |
+| `CERTIFICATE_CLEANUP_ENABLED` | Enables the scheduled orphaned-certificate cleanup                 | ![](https://img.shields.io/badge/-NO-red.svg)      | `true`        |
+| `CERTIFICATE_CLEANUP_INTERVAL_SECONDS` | Interval in seconds between orphaned-certificate cleanup runs | ![](https://img.shields.io/badge/-NO-red.svg)      | `86400`       |
+| `CERTIFICATE_CLEANUP_BATCH_SIZE` | Certificates deleted per transaction by the cleanup            | ![](https://img.shields.io/badge/-NO-red.svg)      | `1000`        |
+
+### Certificate cleanup
+
+PyADCS `Connector` runs a scheduled background task that removes orphaned certificate records left behind by interrupted or failed operations. It is controlled by three environment variables:
+
+- `CERTIFICATE_CLEANUP_ENABLED` — enables or disables the scheduled cleanup (default `true`).
+- `CERTIFICATE_CLEANUP_INTERVAL_SECONDS` — interval, in seconds, between cleanup runs (default `86400`, i.e. once a day).
+- `CERTIFICATE_CLEANUP_BATCH_SIZE` — how many certificates are removed per transaction (default `1000`). The cleanup deletes in batches and releases its lock between them, so a large backlog cannot hold up certificate discovery.
+
+The cleanup runs in a background thread of the served application, at most once per interval across all workers. Two deployment notes: `manage.py runserver` also starts it (set `CERTIFICATE_CLEANUP_ENABLED=false` for local development if that is unwanted), and Gunicorn must not be run with `--preload`, which imports the application in the pre-fork master so the thread starts there and is not inherited by the workers, moving the cleanup outside the worker lifecycle.

--- a/pyadcs_connector/PyADCSConnector/migrations/0002_shared_certificate_store.py
+++ b/pyadcs_connector/PyADCSConnector/migrations/0002_shared_certificate_store.py
@@ -1,0 +1,153 @@
+from django.conf import settings
+from django.db import migrations, models
+
+# Schema prefix used for all tables (see settings.DATABASE_SCHEMA).
+S = settings.DATABASE_SCHEMA
+
+# Fingerprint expression: exact-string SHA-256 of the stored base64content, matching
+# PyADCSConnector.utils.certificate_fingerprint.certificate_fingerprint() byte-for-byte.
+FP = "encode(sha256(convert_to(base64content,'UTF8')),'hex')"
+FP_DC = FP.replace("base64content", "dc.base64content")
+
+
+def seed_certificate_cleanup_state(apps, schema_editor):
+    cleanup_state_model = apps.get_model("PyADCSConnector", "CertificateCleanupState")
+    cleanup_state_model.objects.using(schema_editor.connection.alias).create(last_run_at=None)
+
+
+class Migration(migrations.Migration):
+
+    atomic = True
+
+    dependencies = [
+        ("PyADCSConnector", "0001_initial"),
+    ]
+
+    operations = [
+        # 1. New shared tables.
+        migrations.CreateModel(
+            name="Certificate",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("fingerprint", models.CharField(max_length=64, unique=True)),
+                ("base64content", models.TextField()),
+            ],
+            options={
+                "db_table": f'"{S}"."certificate"',
+            },
+        ),
+        migrations.CreateModel(
+            name="CertificateCleanupState",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("last_run_at", models.DateTimeField(default=None, null=True)),
+            ],
+            options={
+                "db_table": f'"{S}"."certificate_cleanup_state"',
+            },
+        ),
+        # 2. Seed the singleton cleanup-state row.
+        # No reverse_code: this migration is forward-upgrade-only (see the RunSQL backfill
+        # below), so reversing it must fail loudly rather than silently leaving a
+        # half-undone, inconsistent schema.
+        migrations.RunPython(seed_certificate_cleanup_state),
+        # 3. Add the certificate FK, nullable for now so it can be backfilled.
+        migrations.AddField(
+            model_name="discoverycertificate",
+            name="certificate",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=models.PROTECT,
+                to="PyADCSConnector.certificate",
+                db_column="certificate_id",
+                related_name="discovery_links",
+            ),
+        ),
+        # 4. Backfill: dedupe base64content into certificate (only from rows whose
+        #    discovery still exists, so the upgrade never creates immediately-orphaned
+        #    certificate rows), point every discovery_certificate row at its
+        #    certificate, then drop rows with a dangling discovery_id (no matching
+        #    discovery_history).
+        # No reverse_sql: the dedup (dropped duplicate rows) and the dangling-row delete
+        # are lossy and cannot be undone, so this step -- and therefore the whole
+        # migration -- is unambiguously irreversible (forward-upgrade only). Django
+        # raises IrreversibleError rather than silently no-op'ing a partial rollback.
+        migrations.RunSQL(
+            sql=f"""
+            INSERT INTO "{S}"."certificate" (fingerprint, base64content)
+            SELECT fp, base64content FROM (
+              SELECT base64content, {FP} AS fp,
+                     row_number() OVER (PARTITION BY {FP} ORDER BY id) rn
+              FROM "{S}"."discovery_certificate" dc
+              WHERE EXISTS (SELECT 1 FROM "{S}"."discovery_history" dh WHERE dh.id = dc.discovery_id)) s WHERE rn = 1;
+
+            UPDATE "{S}"."discovery_certificate" dc
+              SET certificate_id = c.id FROM "{S}"."certificate" c
+              WHERE c.fingerprint = {FP_DC};
+
+            DELETE FROM "{S}"."discovery_certificate" dc
+              WHERE NOT EXISTS (SELECT 1 FROM "{S}"."discovery_history" dh WHERE dh.id = dc.discovery_id);
+            """,
+        ),
+        # 5. Now that every row has a certificate, enforce NOT NULL.
+        migrations.AlterField(
+            model_name="discoverycertificate",
+            name="certificate",
+            field=models.ForeignKey(
+                on_delete=models.PROTECT,
+                to="PyADCSConnector.certificate",
+                db_column="certificate_id",
+                related_name="discovery_links",
+            ),
+        ),
+        # 6. base64content now lives solely on certificate.
+        migrations.RemoveField(
+            model_name="discoverycertificate",
+            name="base64content",
+        ),
+        # 7. Turn the legacy discovery_id int column into a real FK to discovery_history,
+        #    preserving the data (no drop + re-add).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="discoverycertificate",
+                    name="discovery_id",
+                ),
+                migrations.AddField(
+                    model_name="discoverycertificate",
+                    name="discovery",
+                    field=models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        to="PyADCSConnector.discoveryhistory",
+                        db_column="discovery_id",
+                        related_name="certificate_links",
+                    ),
+                ),
+            ],
+            database_operations=[
+                # No reverse_sql here either: dropping the constraint/index alone would
+                # NOT restore the widened column back to integer, so a "reverse" would
+                # leave discovery_id as bigint while the migration state claims integer
+                # -- exactly the silently-inconsistent partial rollback this migration
+                # must not allow.
+                migrations.RunSQL(
+                    sql=f"""
+                    ALTER TABLE "{S}"."discovery_certificate" ALTER COLUMN discovery_id TYPE bigint;
+                    CREATE INDEX IF NOT EXISTS discovery_certificate_discovery_id_idx ON "{S}"."discovery_certificate" (discovery_id);
+                    ALTER TABLE "{S}"."discovery_certificate"
+                      ADD CONSTRAINT dc_discovery_fk FOREIGN KEY (discovery_id)
+                      REFERENCES "{S}"."discovery_history"(id) DEFERRABLE INITIALLY DEFERRED;
+                    """,
+                ),
+            ],
+        ),
+        # 8. Explicit model index on uuid (certificate_id already gets an automatic FK
+        #    index, so no separate AddIndex for it -- see DiscoveryCertificate.Meta).
+        #    Name computed by Index.set_name_with_model() for this table/field pair; must
+        #    match PyADCSConnector.models.discovery_certificate.DiscoveryCertificate.Meta.indexes
+        #    exactly for `makemigrations --check` to report no drift.
+        migrations.AddIndex(
+            model_name="discoverycertificate",
+            index=models.Index(fields=["uuid"], name="discovery_c_uuid_2cc0e3_idx"),
+        ),
+    ]

--- a/pyadcs_connector/PyADCSConnector/models/__init__.py
+++ b/pyadcs_connector/PyADCSConnector/models/__init__.py
@@ -1,0 +1,5 @@
+from PyADCSConnector.models.authority_instance import AuthorityInstance  # noqa: F401
+from PyADCSConnector.models.discovery_history import DiscoveryHistory  # noqa: F401
+from PyADCSConnector.models.certificate import Certificate  # noqa: F401
+from PyADCSConnector.models.certificate_cleanup_state import CertificateCleanupState  # noqa: F401
+from PyADCSConnector.models.discovery_certificate import DiscoveryCertificate  # noqa: F401

--- a/pyadcs_connector/PyADCSConnector/models/certificate.py
+++ b/pyadcs_connector/PyADCSConnector/models/certificate.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from django.db import models
+
+
+class Certificate(models.Model):
+    fingerprint = models.CharField(max_length=64, unique=True)
+    base64content = models.TextField()
+
+    class Meta:
+        db_table = f'"{settings.DATABASE_SCHEMA}"."certificate"'

--- a/pyadcs_connector/PyADCSConnector/models/certificate_cleanup_state.py
+++ b/pyadcs_connector/PyADCSConnector/models/certificate_cleanup_state.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+from django.db import models
+
+
+class CertificateCleanupState(models.Model):
+    last_run_at = models.DateTimeField(null=True, default=None)
+
+    class Meta:
+        db_table = f'"{settings.DATABASE_SCHEMA}"."certificate_cleanup_state"'

--- a/pyadcs_connector/PyADCSConnector/models/discovery_certificate.py
+++ b/pyadcs_connector/PyADCSConnector/models/discovery_certificate.py
@@ -4,15 +4,22 @@ import json
 from django.conf import settings
 from django.db import models
 
+from PyADCSConnector.models.certificate import Certificate
+from PyADCSConnector.models.discovery_history import DiscoveryHistory
+
 
 class DiscoveryCertificate(models.Model):
     uuid = models.UUIDField(default=uuid.uuid4, editable=False)
-    base64content = models.TextField()
-    discovery_id = models.IntegerField()
     meta = models.JSONField(null=True, default=None)
+    discovery = models.ForeignKey(DiscoveryHistory, on_delete=models.CASCADE,
+                                   db_column="discovery_id", related_name="certificate_links")
+    certificate = models.ForeignKey(Certificate, on_delete=models.PROTECT,
+                                     db_column="certificate_id", related_name="discovery_links")
 
     def __str__(self):
         return json.dumps(self.__dict__)
 
     class Meta:
         db_table = f'"{settings.DATABASE_SCHEMA}"."discovery_certificate"'
+        # No explicit index on "certificate": the FK already auto-creates one on certificate_id.
+        indexes = [models.Index(fields=["uuid"])]

--- a/pyadcs_connector/PyADCSConnector/services/certificate_cleanup.py
+++ b/pyadcs_connector/PyADCSConnector/services/certificate_cleanup.py
@@ -1,0 +1,138 @@
+import logging
+import threading
+import time
+from datetime import timedelta
+
+from django.conf import settings
+from django.db import close_old_connections, connection, transaction
+from psycopg2 import sql
+
+from PyADCSConnector.models.certificate_cleanup_state import CertificateCleanupState
+
+logger = logging.getLogger(__name__)
+
+_started = False
+_lock = threading.Lock()
+
+
+def _schema():
+    return settings.DATABASE_SCHEMA
+
+
+def _claim_lease() -> int | None:
+    """Take the exclusive lock and claim the interval lease in one short transaction.
+
+    Returns the highest certificate id present at claim time (the sweep's upper
+    bound), or None if this process must not sweep now. The lease is claimed up
+    front (not after the deletes) so that at most one sweep per interval runs even
+    if the batched deletion below is interrupted; leftover orphans are simply
+    picked up by the next due sweep.
+    """
+    interval = timedelta(seconds=settings.CERTIFICATE_CLEANUP_INTERVAL_SECONDS)
+    with transaction.atomic():
+        with connection.cursor() as cur:
+            cur.execute("SELECT pg_try_advisory_xact_lock(%s)", [settings.CERTIFICATE_CLEANUP_LOCK_KEY])
+            if not cur.fetchone()[0]:
+                return None  # a discovery or another sweep holds the lock
+
+            # order_by(pk): migration 0002 seeds exactly one row, but pin the choice
+            # so the lease stays deterministic even if a second row ever appeared.
+            state = CertificateCleanupState.objects.select_for_update().order_by("pk").first()
+
+            cur.execute("SELECT now()")
+            now = cur.fetchone()[0]
+
+            if state and state.last_run_at and (now - state.last_run_at) < interval:
+                return None  # not due yet
+
+            if state is None:
+                state = CertificateCleanupState()
+            state.last_run_at = now
+            state.save()
+
+            cur.execute(
+                sql.SQL("SELECT coalesce(max(id), 0) FROM {schema}.{certificate}").format(
+                    schema=sql.Identifier(_schema()),
+                    certificate=sql.Identifier("certificate"),
+                ))
+            return cur.fetchone()[0]
+
+
+def _delete_orphan_batch(batch_size: int, max_certificate_id: int) -> int:
+    """Delete at most batch_size orphaned certificates with id <= max_certificate_id,
+    in one short transaction.
+
+    Re-takes the exclusive lock per batch and releases it on commit, so concurrent
+    discovery persistence (shared lock) only ever waits for a single batch.
+    """
+    with transaction.atomic():
+        with connection.cursor() as cur:
+            cur.execute("SELECT pg_advisory_xact_lock(%s)", [settings.CERTIFICATE_CLEANUP_LOCK_KEY])
+            cur.execute(
+                sql.SQL(
+                    "DELETE FROM {schema}.{certificate} "
+                    "WHERE id IN ("
+                    "SELECT c.id FROM {schema}.{certificate} c "
+                    "WHERE c.id <= %s AND NOT EXISTS ("
+                    "SELECT 1 FROM {schema}.{discovery_certificate} dc "
+                    "WHERE dc.certificate_id = c.id) "
+                    "LIMIT %s)"
+                ).format(
+                    schema=sql.Identifier(_schema()),
+                    certificate=sql.Identifier("certificate"),
+                    discovery_certificate=sql.Identifier("discovery_certificate"),
+                ),
+                [max_certificate_id, batch_size])
+            return cur.rowcount
+
+
+def run_cleanup_once() -> int | None:
+    """Lease-gated, advisory-locked orphan sweep. Returns deleted count if it ran, else None.
+
+    Each sweep only considers certificates that already existed when it claimed the
+    lease, so it always terminates: rows created while it runs (including newly
+    orphaned ones) are left for the next due sweep instead of extending this one
+    indefinitely under continuous churn.
+    """
+    max_certificate_id = _claim_lease()
+    if max_certificate_id is None:
+        return None
+
+    batch_size = max(1, settings.CERTIFICATE_CLEANUP_BATCH_SIZE)
+    deleted = 0
+    while True:
+        in_batch = _delete_orphan_batch(batch_size, max_certificate_id)
+        deleted += in_batch
+        if in_batch < batch_size:
+            break
+
+    logger.info("Orphan certificate cleanup removed %d certificate(s)", deleted)
+    return deleted
+
+
+def _loop():
+    poll = min(settings.CERTIFICATE_CLEANUP_INTERVAL_SECONDS, 3600)
+    while True:
+        close_old_connections()
+        try:
+            run_cleanup_once()
+        except Exception:
+            logger.exception("Orphan certificate cleanup failed")
+        finally:
+            close_old_connections()
+        time.sleep(poll)
+
+
+def start_cleanup_scheduler():
+    global _started
+    if not settings.CERTIFICATE_CLEANUP_ENABLED:
+        return
+    if settings.CERTIFICATE_CLEANUP_INTERVAL_SECONDS <= 0:
+        logger.warning("CERTIFICATE_CLEANUP_INTERVAL_SECONDS must be positive; scheduler disabled")
+        return
+    with _lock:
+        if _started:
+            return
+        _started = True
+    threading.Thread(target=_loop, name="certificate-cleanup", daemon=True).start()
+    logger.info("Certificate cleanup scheduler started")

--- a/pyadcs_connector/PyADCSConnector/services/discovery_history.py
+++ b/pyadcs_connector/PyADCSConnector/services/discovery_history.py
@@ -1,10 +1,11 @@
 import logging
 import threading
 
-from django.db import transaction
+from django.db import connection, transaction
 
-from pyadcs_connector.settings import ADCS_SEARCH_PAGE_SIZE
+from pyadcs_connector.settings import ADCS_SEARCH_PAGE_SIZE, CERTIFICATE_CLEANUP_LOCK_KEY
 from PyADCSConnector.exceptions.already_exist_exception import AlreadyExistException
+from PyADCSConnector.models.certificate import Certificate
 from PyADCSConnector.models.discovery_certificate import DiscoveryCertificate
 from PyADCSConnector.models.discovery_history import DiscoveryHistory
 from PyADCSConnector.objects.authority_instance_attribute import AuthorityInstanceAttribute
@@ -17,6 +18,7 @@ from PyADCSConnector.services.attributes.discovery_attributes import *
 from PyADCSConnector.services.attributes.metadata_attributes import get_ca_name_metadata_attribute, \
     get_template_name_metadata_attribute, get_failed_reason_metadata_attribute
 from PyADCSConnector.utils import attribute_definition_utils
+from PyADCSConnector.utils.certificate_fingerprint import certificate_fingerprint
 from PyADCSConnector.utils.discovery_status import DiscoveryStatus
 from PyADCSConnector.utils.dump_parser import AuthorityData, TemplateData, DumpParser
 
@@ -46,13 +48,13 @@ def run_discovery(form, discovery_history_uuid):
     try:
         discover_certificates(form, discovery_history)
     except Exception as e:
-        discovery_history.status = DiscoveryStatus.FAILED.value
-        discovery_history.meta = [get_failed_reason_metadata_attribute(str(e))]
-        discovery_history.save()
+        # Filtered update (not discovery_history.save()) so a discovery deleted
+        # concurrently during discovery is not resurrected.
+        DiscoveryHistory.objects.filter(uuid=discovery_history_uuid).update(
+            status=DiscoveryStatus.FAILED.value, meta=[get_failed_reason_metadata_attribute(str(e))])
         raise e
 
 
-@transaction.atomic
 def discover_certificates(request_dto, discovery_history):
     logger.info("Starting discovery for %s" % request_dto["name"])
 
@@ -131,17 +133,42 @@ def discover_certificates(request_dto, discovery_history):
 
     session.disconnect()
 
-    for certificate in total_certificates:
-        discovery_certificate = DiscoveryCertificate()
-        discovery_certificate.discovery_id = discovery_history.id
-        discovery_certificate.base64content = certificate.certificate
-        discovery_certificate.meta = get_certificate_meta(cas, certificate.template)
-        discovery_certificate.save()
-
     logger.info("Discovery %s has total %d certificates" % (request_dto["name"], len(total_certificates)))
 
-    discovery_history.status = DiscoveryStatus.COMPLETED.value
-    discovery_history.save()
+    # Persistence happens in one short transaction, after all WinRM I/O has
+    # completed, so we don't hold DB locks for the duration of the (slow,
+    # network-bound) collection above.
+    fingerprints = [certificate_fingerprint(c.certificate) for c in total_certificates]
+    with transaction.atomic():
+        with connection.cursor() as cur:
+            # Shared lock: coordinates with the certificate cleanup sweep's
+            # exclusive lock so a concurrent sweep can't remove certificates
+            # this discovery is about to (re)link.
+            cur.execute("SELECT pg_advisory_xact_lock_shared(%s)", [CERTIFICATE_CLEANUP_LOCK_KEY])
+
+        # Abort if the discovery was deleted while we were collecting via WinRM
+        # (no resurrection of a deleted discovery).
+        dh = DiscoveryHistory.objects.select_for_update().filter(id=discovery_history.id).first()
+        if dh is None:
+            logger.info("Discovery %s was deleted during collection; skipping persistence" % request_dto["name"])
+            return
+
+        unique = dict(zip(fingerprints, total_certificates))
+        # Insert in deterministic (ascending fingerprint) order: two concurrent
+        # discoveries inserting overlapping NEW fingerprints in different orders
+        # can otherwise deadlock against each other in Postgres.
+        Certificate.objects.bulk_create(
+            [Certificate(fingerprint=fp, base64content=c.certificate) for fp, c in sorted(unique.items())],
+            ignore_conflicts=True)
+        id_by_fp = dict(Certificate.objects.filter(fingerprint__in=unique.keys())
+                         .values_list("fingerprint", "id"))
+        DiscoveryCertificate.objects.bulk_create([
+            DiscoveryCertificate(discovery_id=dh.id, certificate_id=id_by_fp[fp],
+                                  meta=get_certificate_meta(cas, cert.template))
+            for fp, cert in zip(fingerprints, total_certificates)])
+
+        dh.status = DiscoveryStatus.COMPLETED.value
+        dh.save(update_fields=["status"])
 
     logger.info("Discovery %s completed" % request_dto["name"])
 
@@ -171,10 +198,11 @@ def get_discovery_history_data(discovery_history_request: DiscoveryHistoryReques
         #     discovery_id=discovery_history.id)[page_number * items_per_page:items_per_page]
         discovery_certificates = DiscoveryCertificate.objects.filter(
             discovery_id=discovery_history.id
-        ).order_by('uuid')[page_number * items_per_page:(page_number + 1) * items_per_page]
+        ).select_related('certificate').order_by('uuid')[
+            page_number * items_per_page:(page_number + 1) * items_per_page]
 
         discovery_history_response.certificate_data = [
-            DiscoveryCertificateDto(val.uuid, val.base64content, val.meta).to_json()
+            DiscoveryCertificateDto(val.uuid, val.certificate.base64content, val.meta).to_json()
             for val in discovery_certificates
         ]
 

--- a/pyadcs_connector/PyADCSConnector/tests_discovery.py
+++ b/pyadcs_connector/PyADCSConnector/tests_discovery.py
@@ -1,0 +1,730 @@
+import base64
+import json
+import uuid
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import psycopg2
+from django.conf import settings
+from django.db import connection
+from django.test import TransactionTestCase, override_settings
+from django.utils import timezone
+
+from PyADCSConnector.models.authority_instance import AuthorityInstance
+from PyADCSConnector.models.certificate import Certificate
+from PyADCSConnector.models.certificate_cleanup_state import CertificateCleanupState
+from PyADCSConnector.models.discovery_certificate import DiscoveryCertificate
+from PyADCSConnector.models.discovery_history import DiscoveryHistory
+from PyADCSConnector.objects.discovery_history_request_dto import DiscoveryHistoryRequestDto
+from PyADCSConnector.services import certificate_cleanup
+from PyADCSConnector.services.attributes.discovery_attributes import (
+    DISCOVERY_AUTHORITY_INSTANCE_ATTRIBUTE_NAME,
+    DISCOVERY_CONFIGSTRING_ATTRIBUTE_NAME,
+    DISCOVERY_SELECT_CA_METHOD_ATTRIBUTE_NAME,
+)
+from PyADCSConnector.services.certificate_cleanup import run_cleanup_once
+from PyADCSConnector.services.discovery_history import (
+    create_discovery_history,
+    discover_certificates,
+    get_discovery_history_data,
+    run_discovery,
+)
+from PyADCSConnector.utils.certificate_fingerprint import certificate_fingerprint
+from PyADCSConnector.utils.discovery_status import DiscoveryStatus
+from PyADCSConnector.utils.dump_parser import DumpParser, ParseResult
+
+
+def _competing_connection():
+    """A second, independent connection to the same database the tests run against,
+    used to hold or probe the advisory lock that discovery persistence uses.
+
+    Built from Django's own connection parameters so the test database name, socket
+    vs TCP host, and any OPTIONS are exactly what Django itself connects with; a
+    connect timeout keeps a misconfigured environment from hanging the suite.
+    """
+    params = connection.get_connection_params()
+    params.setdefault("connect_timeout", 10)
+    return psycopg2.connect(**params)
+
+
+class DiscoveryDeduplicationTests(TransactionTestCase):
+    """
+    Exercises discover_certificates persistence (shared Certificate store +
+    DiscoveryCertificate join) and the read/delete paths that were restructured
+    to match, WITHOUT touching real WinRM: the
+    authority session and DumpParser.parse_certificates are mocked so
+    discover_certificates runs its real dedup/persistence logic against
+    caller-supplied fake certificate content.
+
+    Note on isolation: as documented in tests_migration.py, this app's models
+    declare schema-qualified db_table values (e.g. '"pyadcs"."certificate"'),
+    which defeats TransactionTestCase's introspection-based flush between test
+    methods AND between test classes in the same run -- rows are committed for
+    real and are NOT wiped automatically. Every test method below therefore
+    (a) uses its own uuid-suffixed discovery names / certificate content (see
+    self.run_id) and scopes assertions to the objects it itself created, and
+    (b) explicitly tears down everything it inserted in tearDown(), so a
+    later test module (e.g. tests_migration.py, which migrates this same
+    schema backward and forward) starts from a clean slate rather than
+    tripping over leftover discovery_certificate/certificate rows.
+    """
+
+    def setUp(self):
+        self.run_id = uuid.uuid4().hex[:12]
+        self._discovery_ids = []
+        self.authority = AuthorityInstance.objects.create(
+            name=f"authority-{self.run_id}",
+            address="ca.example.local",
+            https=False,
+            port=5985,
+            attributes={},
+            credential={},
+            kind="PyADCS-WinRM",
+        )
+
+    def tearDown(self):
+        # Cascades DiscoveryCertificate join rows via the FK; any Certificate
+        # left with no remaining discovery_links is this test's own orphan
+        # and is safe to remove too, keeping the shared schema clean for
+        # whichever test module runs next.
+        DiscoveryHistory.objects.filter(id__in=self._discovery_ids).delete()
+        Certificate.objects.filter(discovery_links__isnull=True).delete()
+        self.authority.delete()
+
+    # -- helpers ----------------------------------------------------------
+
+    def _b64(self, label):
+        """A distinct, deterministic fake base64 certificate payload."""
+        return base64.b64encode(f"cert-content-{label}-{self.run_id}".encode()).decode()
+
+    def _request_dto(self, name):
+        return {
+            "name": f"{name}-{self.run_id}",
+            "kind": "PyADCS-WinRM",
+            "attributes": [
+                {"name": DISCOVERY_SELECT_CA_METHOD_ATTRIBUTE_NAME, "content": [{"data": "configstring"}]},
+                {
+                    "name": DISCOVERY_AUTHORITY_INSTANCE_ATTRIBUTE_NAME,
+                    "content": [{"data": {"uuid": str(self.authority.uuid), "name": self.authority.name}}],
+                },
+                {
+                    "name": DISCOVERY_CONFIGSTRING_ATTRIBUTE_NAME,
+                    "content": [{"data": "ca.example.local\\Test CA"}],
+                },
+            ],
+        }
+
+    def _run_discovery(self, name, certs):
+        """
+        Creates a DiscoveryHistory and runs discover_certificates against it,
+        faking the WinRM collection to return `certs` -- a list of
+        (base64content, template_name) tuples -- as if they were parsed from
+        the ADCS dump. Returns the refreshed DiscoveryHistory.
+        """
+        request_dto = self._request_dto(name)
+        discovery_history = create_discovery_history(request_dto)
+        fake_results = [ParseResult(template, content) for content, template in certs]
+
+        with patch(
+            "PyADCSConnector.services.discovery_history.create_session_from_authority_instance",
+            return_value=MagicMock(),
+        ), patch.object(DumpParser, "parse_certificates", return_value=fake_results):
+            discover_certificates(request_dto, discovery_history)
+
+        discovery_history.refresh_from_db()
+        self._discovery_ids.append(discovery_history.id)
+        return discovery_history
+
+    @staticmethod
+    def _paging_request(page_number, items_per_page):
+        return DiscoveryHistoryRequestDto(None, None, page_number, items_per_page)
+
+    # -- tests --------------------------------------------------------------
+
+    def test_dedup_across_two_discoveries(self):
+        """Same certificate content discovered by two separate discoveries
+        collapses to a single Certificate row, with one join row per
+        discovery, each carrying its own uuid/meta."""
+        shared_cert = self._b64("shared")
+
+        d1 = self._run_discovery("disco-shared-1", [(shared_cert, "WebServer")])
+        d2 = self._run_discovery("disco-shared-2", [(shared_cert, "User")])
+
+        fingerprint = certificate_fingerprint(shared_cert)
+        self.assertEqual(Certificate.objects.filter(fingerprint=fingerprint).count(), 1)
+        shared_certificate = Certificate.objects.get(fingerprint=fingerprint)
+        self.assertEqual(shared_certificate.base64content, shared_cert)
+
+        link1 = DiscoveryCertificate.objects.get(discovery_id=d1.id)
+        link2 = DiscoveryCertificate.objects.get(discovery_id=d2.id)
+        self.assertEqual(link1.certificate_id, shared_certificate.id)
+        self.assertEqual(link2.certificate_id, shared_certificate.id)
+        self.assertNotEqual(link1.uuid, link2.uuid)
+        self.assertNotEqual(link1.meta, link2.meta)
+
+        resp1 = get_discovery_history_data(self._paging_request(1, 10), d1)
+        self.assertEqual(resp1.total_certificates_discovered, 1)
+        self.assertEqual(len(resp1.certificate_data), 1)
+        self.assertEqual(resp1.certificate_data[0]["uuid"], link1.uuid)
+        self.assertEqual(resp1.certificate_data[0]["base64Content"], shared_cert)
+        self.assertEqual(resp1.certificate_data[0]["meta"], link1.meta)
+
+        resp2 = get_discovery_history_data(self._paging_request(1, 10), d2)
+        self.assertEqual(resp2.total_certificates_discovered, 1)
+        self.assertEqual(len(resp2.certificate_data), 1)
+        self.assertEqual(resp2.certificate_data[0]["uuid"], link2.uuid)
+        self.assertEqual(resp2.certificate_data[0]["base64Content"], shared_cert)
+        self.assertEqual(resp2.certificate_data[0]["meta"], link2.meta)
+
+    def test_duplicate_within_one_discovery_preserves_both_rows(self):
+        """The same certificate discovered twice within a single discovery
+        still yields two join rows (duplicate count preserved), backed by a
+        single Certificate row."""
+        dup_cert = self._b64("dup-in-one")
+
+        d = self._run_discovery("disco-dup-one", [(dup_cert, "WebServer"), (dup_cert, "WebServer")])
+
+        fingerprint = certificate_fingerprint(dup_cert)
+        self.assertEqual(Certificate.objects.filter(fingerprint=fingerprint).count(), 1)
+
+        links = list(DiscoveryCertificate.objects.filter(discovery_id=d.id))
+        self.assertEqual(len(links), 2)
+        self.assertNotEqual(links[0].uuid, links[1].uuid)
+        for link in links:
+            self.assertEqual(link.certificate.fingerprint, fingerprint)
+
+        resp = get_discovery_history_data(self._paging_request(1, 100), d)
+        self.assertEqual(resp.total_certificates_discovered, 2)
+        self.assertEqual(len(resp.certificate_data), 2)
+
+    def test_response_shape_order_and_pagination_parity(self):
+        """DTO shape, order_by('uuid'), pagination math, and the reported
+        total match the pre-dedup semantics -- just sourced via the join."""
+        certs = [(self._b64(f"resp-{i}"), "WebServer") for i in range(3)]
+
+        d = self._run_discovery("disco-resp-parity", certs)
+
+        all_links = list(DiscoveryCertificate.objects.filter(discovery_id=d.id).order_by("uuid"))
+        self.assertEqual(len(all_links), 3)
+
+        # itemsPerPage=2 forces a second page; pageNumber is 1-indexed at the
+        # DTO boundary (get_discovery_history_data converts to 0-indexed).
+        resp_page1 = get_discovery_history_data(self._paging_request(1, 2), d)
+        resp_page2 = get_discovery_history_data(self._paging_request(2, 2), d)
+
+        self.assertEqual(resp_page1.total_certificates_discovered, 3)
+        self.assertEqual(resp_page2.total_certificates_discovered, 3)
+        self.assertEqual(len(resp_page1.certificate_data), 2)
+        self.assertEqual(len(resp_page2.certificate_data), 1)
+
+        combined = resp_page1.certificate_data + resp_page2.certificate_data
+        self.assertEqual(len(combined), len(all_links))
+        for entry, link in zip(combined, all_links):
+            self.assertEqual(set(entry.keys()), {"uuid", "base64Content", "meta"})
+            self.assertEqual(entry["uuid"], link.uuid)
+            self.assertEqual(entry["base64Content"], link.certificate.base64content)
+            self.assertEqual(entry["meta"], link.meta)
+
+    def test_delete_discovery_cascades_join_rows_and_preserves_shared_certificate(self):
+        """Deleting a DiscoveryHistory cascades its DiscoveryCertificate join
+        rows via the ORM FK, but leaves a Certificate still referenced by
+        another discovery untouched (removing newly-orphaned certificates is
+        the scheduled sweep's job, not the delete path's)."""
+        shared_cert = self._b64("delete-shared")
+
+        d1 = self._run_discovery("disco-del-1", [(shared_cert, "WebServer")])
+        d2 = self._run_discovery("disco-del-2", [(shared_cert, "WebServer")])
+
+        fingerprint = certificate_fingerprint(shared_cert)
+        certificate_id = Certificate.objects.get(fingerprint=fingerprint).id
+        self.assertTrue(DiscoveryCertificate.objects.filter(discovery_id=d1.id).exists())
+
+        d1.delete()
+
+        self.assertFalse(DiscoveryCertificate.objects.filter(discovery_id=d1.id).exists())
+        self.assertTrue(DiscoveryCertificate.objects.filter(discovery_id=d2.id).exists())
+        self.assertTrue(Certificate.objects.filter(id=certificate_id).exists())
+
+    def test_fingerprint_python_sql_parity(self):
+        """certificate_fingerprint(x) must match Postgres'
+        encode(sha256(convert_to(x,'UTF8')),'hex') exactly, including for
+        content with embedded newlines/tabs, since migration 0002 used this SQL
+        expression to compute the same fingerprints the discovery path computes
+        in Python."""
+        samples = [
+            "cGxhaW4tYmFzZTY0LWNvbnRlbnQ=" + self.run_id,  # plain
+            "d3JhcHBlZC1iYXNlNjQtY29udGVudA==\nTU9SRV9MSU5FX1RXTw==\nQU5EX0xJTkVfVEhSRUU=",  # newline-wrapped
+            "dGFiLXNlcGFyYXRlZC1jb250ZW50\t\tsuffix\tvalue",  # tab-containing
+        ]
+        with connection.cursor() as cursor:
+            for sample in samples:
+                with self.subTest(sample=sample):
+                    python_fingerprint = certificate_fingerprint(sample)
+                    cursor.execute("SELECT encode(sha256(convert_to(%s, 'UTF8')), 'hex')", [sample])
+                    sql_fingerprint = cursor.fetchone()[0]
+                    self.assertEqual(python_fingerprint, sql_fingerprint)
+
+    def test_new_certificates_inserted_in_ascending_fingerprint_order(self):
+        """Two concurrent discoveries inserting overlapping NEW fingerprints
+        in different orders can deadlock in Postgres; discover_certificates
+        must always hand bulk_create a deterministic (ascending-fingerprint)
+        list regardless of the order certificates were collected in. This is
+        a deterministic, single-threaded assertion on the argument order --
+        not a flaky real-thread race."""
+        candidates = [self._b64(f"order-{i}") for i in range(5)]
+        # Feed discover_certificates the certs in descending-fingerprint
+        # order: an implementation that didn't sort would then hand
+        # bulk_create that same (wrong) descending order.
+        candidates.sort(key=certificate_fingerprint, reverse=True)
+        certs = [(content, "WebServer") for content in candidates]
+
+        original_bulk_create = Certificate.objects.bulk_create
+        captured = {}
+
+        def _capturing_bulk_create(objs, **kwargs):
+            objs = list(objs)
+            captured["fingerprints"] = [o.fingerprint for o in objs]
+            return original_bulk_create(objs, **kwargs)
+
+        request_dto = self._request_dto("disco-order")
+        discovery_history = create_discovery_history(request_dto)
+        fake_results = [ParseResult(template, content) for content, template in certs]
+
+        with patch(
+            "PyADCSConnector.services.discovery_history.create_session_from_authority_instance",
+            return_value=MagicMock(),
+        ), patch.object(DumpParser, "parse_certificates", return_value=fake_results), patch.object(
+            Certificate.objects, "bulk_create", side_effect=_capturing_bulk_create,
+        ):
+            discover_certificates(request_dto, discovery_history)
+        self._discovery_ids.append(discovery_history.id)
+
+        self.assertIn("fingerprints", captured)
+        self.assertEqual(captured["fingerprints"], sorted(captured["fingerprints"]))
+        # Sanity check the test actually set up a non-trivial (not already
+        # ascending) input order, so the assertion above is meaningful.
+        self.assertNotEqual([certificate_fingerprint(c) for c in candidates], captured["fingerprints"])
+
+    def test_discover_certificates_returns_early_if_discovery_deleted_before_persistence(self):
+        """If the DiscoveryHistory row is gone by the time the (post-WinRM)
+        persistence transaction runs -- e.g. deleted by a concurrent DELETE
+        while collection was still in progress -- discover_certificates must
+        return quietly rather than resurrect the discovery, raise, or
+        persist anything."""
+        cert = self._b64("deleted-during-collection")
+        request_dto = self._request_dto("disco-deleted-mid-flight")
+        discovery_history = create_discovery_history(request_dto)
+        discovery_id = discovery_history.id
+
+        # Simulate a concurrent DELETE landing after WinRM collection
+        # finished (mocked below) but before the persistence transaction runs.
+        DiscoveryHistory.objects.filter(id=discovery_id).delete()
+
+        fake_results = [ParseResult("WebServer", cert)]
+        with patch(
+            "PyADCSConnector.services.discovery_history.create_session_from_authority_instance",
+            return_value=MagicMock(),
+        ), patch.object(DumpParser, "parse_certificates", return_value=fake_results):
+            discover_certificates(request_dto, discovery_history)  # must not raise
+
+        fingerprint = certificate_fingerprint(cert)
+        self.assertFalse(DiscoveryCertificate.objects.filter(discovery_id=discovery_id).exists())
+        self.assertFalse(Certificate.objects.filter(fingerprint=fingerprint).exists())
+
+    def test_run_discovery_marks_failed_status_on_exception(self):
+        """run_discovery's except-branch uses a filtered .update() (not
+        discovery_history.save()) precisely so a concurrently-deleted
+        discovery isn't resurrected; this test exercises the normal
+        (still-existing) case: status flips to FAILED with a failure-reason
+        meta entry, and the original exception still propagates to the
+        caller/thread."""
+        request_dto = self._request_dto("disco-run-fails")
+        discovery_history = create_discovery_history(request_dto)
+        self._discovery_ids.append(discovery_history.id)
+
+        boom = RuntimeError("simulated WinRM failure")
+        with patch(
+            "PyADCSConnector.services.discovery_history.create_session_from_authority_instance",
+            side_effect=boom,
+        ):
+            with self.assertRaises(RuntimeError):
+                run_discovery(request_dto, discovery_history.uuid)
+
+        discovery_history.refresh_from_db()
+        self.assertEqual(discovery_history.status, DiscoveryStatus.FAILED.value)
+        self.assertEqual(len(discovery_history.meta), 1)
+        self.assertEqual(discovery_history.meta[0]["content"][0]["data"], str(boom))
+
+
+class CertificateCleanupTests(TransactionTestCase):
+    """
+    Exercises the scheduled orphan sweep (run_cleanup_once): the
+    advisory-lock-gated, DB-clock-leased, batched DELETE that removes
+    Certificate rows with no remaining discovery_certificate join rows.
+
+    Same schema-qualified-table caveat as DiscoveryDeduplicationTests above:
+    rows (including the singleton-ish CertificateCleanupState row) are NOT
+    wiped automatically between tests, so setUp/tearDown here explicitly
+    reset both the cleanup-state table and any stray orphan Certificate rows
+    to keep this class self-contained and safe to run repeatedly.
+    """
+
+    def setUp(self):
+        self.run_id = uuid.uuid4().hex[:12]
+        self._discovery_ids = []
+        # Clean slate: no lease state, no pre-existing orphans from another
+        # test module/run, so deleted-count assertions below are exact.
+        CertificateCleanupState.objects.all().delete()
+        Certificate.objects.filter(discovery_links__isnull=True).delete()
+
+    def tearDown(self):
+        DiscoveryHistory.objects.filter(id__in=self._discovery_ids).delete()
+        Certificate.objects.filter(discovery_links__isnull=True).delete()
+        CertificateCleanupState.objects.all().delete()
+
+    # -- helpers ----------------------------------------------------------
+
+    def _b64(self, label):
+        return base64.b64encode(f"cleanup-cert-{label}-{self.run_id}".encode()).decode()
+
+    def _make_certificate(self, label):
+        content = self._b64(label)
+        return Certificate.objects.create(
+            fingerprint=certificate_fingerprint(content), base64content=content)
+
+    def _make_discovery(self, name):
+        discovery = DiscoveryHistory.objects.create(
+            name=f"{name}-{self.run_id}", status=DiscoveryStatus.COMPLETED.value)
+        self._discovery_ids.append(discovery.id)
+        return discovery
+
+    def _link(self, discovery, certificate):
+        return DiscoveryCertificate.objects.create(
+            discovery_id=discovery.id, certificate_id=certificate.id, meta=None)
+
+    # -- tests --------------------------------------------------------------
+
+    def test_orphan_deleted_linked_certificate_kept(self):
+        """A Certificate with no discovery_certificate join row is swept;
+        one still referenced by a discovery survives."""
+        discovery = self._make_discovery("cleanup-linked")
+        linked_certificate = self._make_certificate("linked")
+        self._link(discovery, linked_certificate)
+        orphan_certificate = self._make_certificate("orphan")
+
+        deleted = run_cleanup_once()
+
+        self.assertEqual(deleted, 1)
+        self.assertFalse(Certificate.objects.filter(id=orphan_certificate.id).exists())
+        self.assertTrue(Certificate.objects.filter(id=linked_certificate.id).exists())
+
+    def test_lease_blocks_immediate_rerun_then_allows_once_due(self):
+        """An immediate second call is a no-op (lease not due yet); once the
+        lease is (simulated to be) due again, the sweep runs anew."""
+        with override_settings(CERTIFICATE_CLEANUP_INTERVAL_SECONDS=3600):
+            first_orphan = self._make_certificate("lease-first")
+
+            first_run = run_cleanup_once()
+            self.assertEqual(first_run, 1)
+            self.assertFalse(Certificate.objects.filter(id=first_orphan.id).exists())
+
+            second_orphan = self._make_certificate("lease-second")
+
+            second_run = run_cleanup_once()
+            self.assertIsNone(second_run)
+            self.assertTrue(Certificate.objects.filter(id=second_orphan.id).exists())
+
+            # Simulate the interval having elapsed since the last run.
+            CertificateCleanupState.objects.update(
+                last_run_at=timezone.now() - timedelta(hours=2))
+
+            third_run = run_cleanup_once()
+            self.assertEqual(third_run, 1)
+            self.assertFalse(Certificate.objects.filter(id=second_orphan.id).exists())
+
+    def test_sweep_skips_while_a_discovery_holds_the_shared_lock(self):
+        """The core safety property: while another connection holds the shared
+        advisory lock (as discovery persistence does), the sweep must not delete
+        anything -- it cannot take the exclusive lock, so it returns None and
+        leaves the lease untouched. Once that lock is released it sweeps."""
+        orphan = self._make_certificate("lock-held")
+
+        blocker = _competing_connection()
+        try:
+            # Transaction-scoped shared lock, held open by not committing.
+            with blocker.cursor() as blocking_cursor:
+                blocking_cursor.execute(
+                    "SELECT pg_advisory_xact_lock_shared(%s)",
+                    [settings.CERTIFICATE_CLEANUP_LOCK_KEY])
+
+                self.assertIsNone(run_cleanup_once())
+                self.assertTrue(Certificate.objects.filter(id=orphan.id).exists())
+                # Lease untouched, so the sweep is still due once the lock frees.
+                self.assertFalse(
+                    CertificateCleanupState.objects.filter(last_run_at__isnull=False).exists())
+        finally:
+            blocker.rollback()  # releases the transaction-scoped lock
+            blocker.close()
+
+        self.assertEqual(run_cleanup_once(), 1)
+        self.assertFalse(Certificate.objects.filter(id=orphan.id).exists())
+
+    def test_sweep_deletes_across_multiple_batches(self):
+        """With a batch size smaller than the backlog, the sweep loops until
+        drained and reports the full count."""
+        orphans = [self._make_certificate(f"batch-{index}") for index in range(5)]
+
+        with override_settings(CERTIFICATE_CLEANUP_BATCH_SIZE=2):
+            deleted = run_cleanup_once()
+
+        self.assertEqual(deleted, 5)
+        self.assertFalse(
+            Certificate.objects.filter(id__in=[orphan.id for orphan in orphans]).exists())
+
+    def test_exclusive_lock_is_released_between_batches(self):
+        """The point of batching: the sweep must not hold its exclusive lock for
+        the whole run. Probed from a second connection at every batch boundary --
+        a competing shared lock (what discovery persistence takes) has to be
+        grantable there, which it would not be if one lock spanned the sweep."""
+        for index in range(4):
+            self._make_certificate(f"release-{index}")
+
+        real_delete_batch = certificate_cleanup._delete_orphan_batch
+        shared_lock_grantable = []
+
+        def delete_then_probe(batch_size, max_certificate_id):
+            deleted = real_delete_batch(batch_size, max_certificate_id)
+            probe = _competing_connection()
+            try:
+                with probe.cursor() as probe_cursor:
+                    probe_cursor.execute(
+                        "SELECT pg_try_advisory_xact_lock_shared(%s)",
+                        [settings.CERTIFICATE_CLEANUP_LOCK_KEY])
+                    shared_lock_grantable.append(probe_cursor.fetchone()[0])
+            finally:
+                probe.rollback()
+                probe.close()
+            return deleted
+
+        with override_settings(CERTIFICATE_CLEANUP_BATCH_SIZE=2), patch.object(
+                certificate_cleanup, "_delete_orphan_batch", delete_then_probe):
+            run_cleanup_once()
+
+        # More than one boundary observed, and the lock was free at each of them.
+        self.assertGreater(len(shared_lock_grantable), 1)
+        self.assertTrue(all(shared_lock_grantable))
+
+    def test_sweep_is_bounded_to_certificates_present_at_start(self):
+        """Certificates orphaned after the sweep claimed its lease are left for
+        the next run, so continuous churn cannot keep a sweep -- and its lock
+        contention -- going indefinitely."""
+        existing = [self._make_certificate(f"churn-{index}") for index in range(3)]
+        late_orphans = []
+        real_delete_batch = certificate_cleanup._delete_orphan_batch
+
+        def delete_then_churn(batch_size, max_certificate_id):
+            deleted = real_delete_batch(batch_size, max_certificate_id)
+            if not late_orphans:  # create a fresh orphan mid-sweep, once
+                late_orphans.append(self._make_certificate("churn-late"))
+            return deleted
+
+        with override_settings(CERTIFICATE_CLEANUP_BATCH_SIZE=2), patch.object(
+                certificate_cleanup, "_delete_orphan_batch", delete_then_churn):
+            deleted = run_cleanup_once()
+
+        # Only the three pre-existing orphans; the one created mid-sweep survives.
+        self.assertEqual(deleted, 3)
+        self.assertFalse(
+            Certificate.objects.filter(id__in=[cert.id for cert in existing]).exists())
+        self.assertTrue(Certificate.objects.filter(id=late_orphans[0].id).exists())
+
+
+class CertificateCleanupSchedulerTests(TransactionTestCase):
+    """
+    Exercises start_cleanup_scheduler()'s guards -- disabled, non-positive
+    interval, and the started-once/idempotent-second-call behavior -- with
+    threading.Thread patched out so no real background thread or sleep loop
+    ever runs.
+    """
+
+    def setUp(self):
+        certificate_cleanup._started = False
+
+    def tearDown(self):
+        certificate_cleanup._started = False
+
+    def test_disabled_starts_no_thread(self):
+        with override_settings(CERTIFICATE_CLEANUP_ENABLED=False), patch(
+            "PyADCSConnector.services.certificate_cleanup.threading.Thread"
+        ) as thread_cls:
+            certificate_cleanup.start_cleanup_scheduler()
+
+        thread_cls.assert_not_called()
+        self.assertFalse(certificate_cleanup._started)
+
+    def test_non_positive_interval_warns_and_starts_no_thread(self):
+        with override_settings(
+            CERTIFICATE_CLEANUP_ENABLED=True, CERTIFICATE_CLEANUP_INTERVAL_SECONDS=0
+        ), patch("PyADCSConnector.services.certificate_cleanup.threading.Thread") as thread_cls, \
+                self.assertLogs("PyADCSConnector.services.certificate_cleanup", level="WARNING") as logs:
+            certificate_cleanup.start_cleanup_scheduler()
+
+        thread_cls.assert_not_called()
+        self.assertFalse(certificate_cleanup._started)
+        self.assertTrue(any("must be positive" in message for message in logs.output))
+
+    def test_enabled_starts_thread_once_second_call_is_noop(self):
+        with override_settings(
+            CERTIFICATE_CLEANUP_ENABLED=True, CERTIFICATE_CLEANUP_INTERVAL_SECONDS=60
+        ), patch("PyADCSConnector.services.certificate_cleanup.threading.Thread") as thread_cls:
+            certificate_cleanup.start_cleanup_scheduler()
+            certificate_cleanup.start_cleanup_scheduler()
+
+        thread_cls.assert_called_once()
+        thread_cls.return_value.start.assert_called_once()
+        self.assertTrue(certificate_cleanup._started)
+
+
+class DiscoveryViewsTests(TransactionTestCase):
+    """
+    Exercises the HTTP views in views/discovery_history.py end-to-end via
+    Django's test Client: start_discovery's background Thread is patched out
+    (asserting only that a DiscoveryHistory row is created, no real WinRM/
+    thread runs), and discovery_operations POST (data retrieval)/DELETE are
+    exercised against a discovery seeded the same way as
+    DiscoveryDeduplicationTests._run_discovery above.
+
+    Same schema-qualified-table caveat as the other classes in this module:
+    tearDown explicitly cleans up everything this class creates.
+    """
+
+    def setUp(self):
+        self.run_id = uuid.uuid4().hex[:12]
+        self._discovery_ids = []
+        self.authority = AuthorityInstance.objects.create(
+            name=f"authority-views-{self.run_id}",
+            address="ca.example.local",
+            https=False,
+            port=5985,
+            attributes={},
+            credential={},
+            kind="PyADCS-WinRM",
+        )
+
+    def tearDown(self):
+        DiscoveryHistory.objects.filter(id__in=self._discovery_ids).delete()
+        Certificate.objects.filter(discovery_links__isnull=True).delete()
+        self.authority.delete()
+
+    # -- helpers ----------------------------------------------------------
+
+    def _b64(self, label):
+        return base64.b64encode(f"views-cert-{label}-{self.run_id}".encode()).decode()
+
+    def _request_dto(self, name):
+        return {
+            "name": f"{name}-{self.run_id}",
+            "kind": "PyADCS-WinRM",
+            "attributes": [
+                {"name": DISCOVERY_SELECT_CA_METHOD_ATTRIBUTE_NAME, "content": [{"data": "configstring"}]},
+                {
+                    "name": DISCOVERY_AUTHORITY_INSTANCE_ATTRIBUTE_NAME,
+                    "content": [{"data": {"uuid": str(self.authority.uuid), "name": self.authority.name}}],
+                },
+                {
+                    "name": DISCOVERY_CONFIGSTRING_ATTRIBUTE_NAME,
+                    "content": [{"data": "ca.example.local\\Test CA"}],
+                },
+            ],
+        }
+
+    def _seed_discovery(self, name, certs):
+        """Builds a real DiscoveryHistory + DiscoveryCertificate/Certificate
+        rows by calling discover_certificates directly with WinRM mocked
+        out -- same approach as DiscoveryDeduplicationTests._run_discovery."""
+        request_dto = self._request_dto(name)
+        discovery_history = create_discovery_history(request_dto)
+        fake_results = [ParseResult(template, content) for content, template in certs]
+
+        with patch(
+            "PyADCSConnector.services.discovery_history.create_session_from_authority_instance",
+            return_value=MagicMock(),
+        ), patch.object(DumpParser, "parse_certificates", return_value=fake_results):
+            discover_certificates(request_dto, discovery_history)
+
+        discovery_history.refresh_from_db()
+        self._discovery_ids.append(discovery_history.id)
+        return discovery_history
+
+    # -- tests --------------------------------------------------------------
+
+    def test_start_discovery_creates_discovery_and_returns_200(self):
+        body = {"name": f"view-start-{self.run_id}", "kind": "PyADCS-WinRM", "attributes": []}
+
+        with patch("PyADCSConnector.views.discovery_history.Thread") as thread_cls:
+            response = self.client.post(
+                "/v1/discoveryProvider/discover", data=json.dumps(body), content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+        thread_cls.assert_called_once()
+        thread_cls.return_value.start.assert_called_once()
+
+        created = DiscoveryHistory.objects.get(name=body["name"])
+        self._discovery_ids.append(created.id)
+
+        payload = response.json()
+        self.assertEqual(payload["name"], body["name"])
+        self.assertEqual(payload["uuid"], str(created.uuid))
+        self.assertEqual(payload["status"], DiscoveryStatus.IN_PROGRESS.value)
+        self.assertEqual(payload["certificateData"], [])
+        self.assertEqual(payload["totalCertificatesDiscovered"], 0)
+
+    def test_discovery_operations_post_existing_returns_data(self):
+        cert = self._b64("post-existing")
+        discovery = self._seed_discovery("view-post-existing", [(cert, "WebServer")])
+
+        body = {"name": discovery.name, "kind": "PyADCS-WinRM", "pageNumber": 1, "itemsPerPage": 10}
+        response = self.client.post(
+            f"/v1/discoveryProvider/discover/{discovery.uuid}",
+            data=json.dumps(body), content_type="application/json")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["uuid"], str(discovery.uuid))
+        self.assertEqual(payload["name"], discovery.name)
+        self.assertEqual(payload["totalCertificatesDiscovered"], 1)
+        self.assertEqual(len(payload["certificateData"]), 1)
+        self.assertEqual(set(payload["certificateData"][0].keys()), {"uuid", "base64Content", "meta"})
+
+    def test_discovery_operations_post_missing_returns_404(self):
+        missing_uuid = uuid.uuid4()
+        body = {"name": "whatever", "kind": "PyADCS-WinRM", "pageNumber": 1, "itemsPerPage": 10}
+
+        response = self.client.post(
+            f"/v1/discoveryProvider/discover/{missing_uuid}",
+            data=json.dumps(body), content_type="application/json")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(str(missing_uuid), response.json()["message"])
+
+    def test_discovery_operations_delete_existing_returns_204_and_cascades(self):
+        shared_cert = self._b64("delete-view-shared")
+        d1 = self._seed_discovery("view-del-1", [(shared_cert, "WebServer")])
+        d2 = self._seed_discovery("view-del-2", [(shared_cert, "WebServer")])
+        certificate_id = Certificate.objects.get(fingerprint=certificate_fingerprint(shared_cert)).id
+
+        response = self.client.delete(f"/v1/discoveryProvider/discover/{d1.uuid}")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(DiscoveryHistory.objects.filter(id=d1.id).exists())
+        self.assertFalse(DiscoveryCertificate.objects.filter(discovery_id=d1.id).exists())
+        self.assertTrue(DiscoveryHistory.objects.filter(id=d2.id).exists())
+        self.assertTrue(Certificate.objects.filter(id=certificate_id).exists())
+
+    def test_discovery_operations_delete_missing_returns_404(self):
+        missing_uuid = uuid.uuid4()
+
+        response = self.client.delete(f"/v1/discoveryProvider/discover/{missing_uuid}")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(str(missing_uuid), response.json()["message"])

--- a/pyadcs_connector/PyADCSConnector/tests_migration.py
+++ b/pyadcs_connector/PyADCSConnector/tests_migration.py
@@ -1,0 +1,264 @@
+import json
+import uuid
+
+from django.conf import settings
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+from psycopg2 import sql
+
+from PyADCSConnector.utils.certificate_fingerprint import certificate_fingerprint
+
+S = settings.DATABASE_SCHEMA
+
+
+class SharedCertificateStoreMigrationTest(TransactionTestCase):
+    """
+    Exercises migration 0001_initial -> 0002_shared_certificate_store against
+    legacy-shaped discovery_certificate data (raw rows with base64content and a
+    plain discovery_id int, as they existed before the shared certificate store).
+
+    Verifies: exact-string fingerprint de-duplication, association preservation,
+    dangling discovery_id cleanup, base64content column removal, and the resulting
+    schema shape (unique fingerprint index, FKs, index on certificate_id, discovery_id
+    now bigint).
+
+    Deliberately a single test method: this app's models declare fully
+    schema-qualified db_table values (e.g. '"pyadcs"."certificate"'), which Django's
+    introspection-based `flush` (used by TransactionTestCase between test methods)
+    fails to match against bare introspected table names, so it silently skips
+    flushing them. A single method keeps the whole seed -> migrate -> assert cycle
+    self-contained in one setUp, sidestepping that mismatch; individual assertion
+    groups are still reported separately via subTest.
+
+    Migration 0002 is intentionally, unambiguously irreversible (its data
+    RunPython/RunSQL steps have no reverse_code/reverse_sql), so this fixture cannot
+    seed 0001-shaped data by reversing an already-applied 0002 -- that path would now
+    raise IrreversibleError, and even before that change it left discovery_id
+    physically bigint (only the migration *state* rolled back to int), which would
+    have quietly skipped exercising a genuine int->bigint conversion. Instead, this
+    test drops and recreates the whole schema so migrating to 0001 is a real forward
+    apply from nothing, guaranteeing discovery_id is genuinely a plain integer column
+    before the legacy rows go in and 0002 forward-migrates them for real.
+    """
+
+    migrate_from = [("PyADCSConnector", "0001_initial")]
+    migrate_to = [("PyADCSConnector", "0002_shared_certificate_store")]
+
+    # Legacy discovery_certificate content values, keyed by scenario.
+    CERT_SHARED = "U0hBUkVEX0NFUlRfQ09OVEVOVA=="  # shared across two discoveries
+    CERT_DUP_ONE = "RFVQTElDQVRFRF9JTl9PTkVfRElTQ09WRVJZ"  # duplicated within one discovery
+    CERT_WS_A = "V0hJVEVTUEFDRV9WQVJJQU5UX0E="  # whitespace-sensitive pair:
+    CERT_WS_B = CERT_WS_A + " "  # ...differs only by a trailing space, must NOT dedup
+    CERT_DANGLING = "REFOR0xJTkdfQ0VSVElGSUNBVEU="  # attached to a non-existent discovery
+
+    def setUp(self):
+        # Genuinely fresh start: drop the whole schema (django_migrations included --
+        # it lives here too, since the connection's search_path is pinned to this
+        # schema) and recreate it empty, so the migrate-to-0001 below is a real
+        # forward apply from nothing rather than a reverse of an already-applied 0002.
+        with connection.cursor() as cursor:
+            cursor.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(S)))
+            cursor.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(S)))
+
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        executor.loader.build_graph()
+
+        # Seed two real discoveries using the historical (0001) model state.
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        history_model = old_apps.get_model("PyADCSConnector", "DiscoveryHistory")
+        discovery_a = history_model.objects.create(
+            uuid=uuid.uuid4(), name="disco-a", status="COMPLETED", meta=None
+        )
+        discovery_b = history_model.objects.create(
+            uuid=uuid.uuid4(), name="disco-b", status="COMPLETED", meta=None
+        )
+        self.discovery_a_id = discovery_a.id
+        self.discovery_b_id = discovery_b.id
+        # Guaranteed not to exist in discovery_history.
+        self.dangling_discovery_id = discovery_b.id + 1000
+
+        # (base64content, discovery_id, meta) legacy rows.
+        legacy_rows = [
+            (self.CERT_SHARED, self.discovery_a_id, {"scenario": "shared", "side": "a"}),
+            (self.CERT_SHARED, self.discovery_b_id, {"scenario": "shared", "side": "b"}),
+            (self.CERT_DUP_ONE, self.discovery_a_id, {"scenario": "dup-one", "copy": 1}),
+            (self.CERT_DUP_ONE, self.discovery_a_id, {"scenario": "dup-one", "copy": 2}),
+            (self.CERT_WS_A, self.discovery_a_id, {"scenario": "ws-a"}),
+            (self.CERT_WS_B, self.discovery_b_id, {"scenario": "ws-b"}),
+            (self.CERT_DANGLING, self.dangling_discovery_id, {"scenario": "dangling"}),
+        ]
+
+        # Track every seeded row by its own uuid so post-migration assertions can
+        # verify each surviving discovery_certificate row individually.
+        self.seeded_rows = {}
+        insert_stmt = sql.SQL(
+            "INSERT INTO {}.{} (uuid, base64content, discovery_id, meta) "
+            "VALUES (%s, %s, %s, %s)"
+        ).format(sql.Identifier(S), sql.Identifier("discovery_certificate"))
+        with connection.cursor() as cursor:
+            for base64content, discovery_id, meta in legacy_rows:
+                row_uuid = uuid.uuid4()
+                self.seeded_rows[str(row_uuid)] = {
+                    "base64content": base64content,
+                    "discovery_id": discovery_id,
+                    "meta": meta,
+                }
+                cursor.execute(
+                    insert_stmt,
+                    [str(row_uuid), base64content, discovery_id, json.dumps(meta)],
+                )
+
+        self.dangling_row_uuid = next(
+            row_uuid
+            for row_uuid, row in self.seeded_rows.items()
+            if row["meta"]["scenario"] == "dangling"
+        )
+
+        # Run the migration under test.
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        executor.migrate(self.migrate_to)
+        self.new_apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        # This test seeds real discoveries/certificates/join rows (and 0002's forward
+        # RunPython seeds a CertificateCleanupState row) directly against the shared
+        # schema, which -- as noted above -- TransactionTestCase's flush cannot clear
+        # between runs. setUp's schema drop/recreate already makes this test's own
+        # re-run self-cleaning, but delete the seeded rows explicitly anyway: this is
+        # the only place they're created, and leaving them around would otherwise be
+        # the sole source of leftover data for anything else that inspects this
+        # (--keepdb'd) database afterward.
+        history_model = self.new_apps.get_model("PyADCSConnector", "DiscoveryHistory")
+        certificate_model = self.new_apps.get_model("PyADCSConnector", "Certificate")
+        cleanup_state_model = self.new_apps.get_model("PyADCSConnector", "CertificateCleanupState")
+
+        history_model.objects.filter(id__in=[self.discovery_a_id, self.discovery_b_id]).delete()
+        certificate_model.objects.all().delete()
+        cleanup_state_model.objects.all().delete()
+
+    def test_migration_0001_to_0002(self):
+        certificate_model = self.new_apps.get_model("PyADCSConnector", "Certificate")
+        discovery_certificate_model = self.new_apps.get_model("PyADCSConnector", "DiscoveryCertificate")
+
+        with self.subTest("exact-match content collapses to a single certificate"):
+            self.assertEqual(certificate_model.objects.filter(base64content=self.CERT_SHARED).count(), 1)
+            self.assertEqual(certificate_model.objects.filter(base64content=self.CERT_DUP_ONE).count(), 1)
+
+        with self.subTest("whitespace-varied content does NOT dedup"):
+            self.assertEqual(certificate_model.objects.filter(base64content=self.CERT_WS_A).count(), 1)
+            self.assertEqual(certificate_model.objects.filter(base64content=self.CERT_WS_B).count(), 1)
+            cert_ws_a = certificate_model.objects.get(base64content=self.CERT_WS_A)
+            cert_ws_b = certificate_model.objects.get(base64content=self.CERT_WS_B)
+            self.assertNotEqual(cert_ws_a.id, cert_ws_b.id)
+            self.assertNotEqual(cert_ws_a.fingerprint, cert_ws_b.fingerprint)
+            self.assertEqual(cert_ws_a.fingerprint, certificate_fingerprint(self.CERT_WS_A))
+            self.assertEqual(cert_ws_b.fingerprint, certificate_fingerprint(self.CERT_WS_B))
+
+        with self.subTest("fingerprint matches the documented sha256(utf8) helper"):
+            cert_shared = certificate_model.objects.get(base64content=self.CERT_SHARED)
+            self.assertEqual(cert_shared.fingerprint, certificate_fingerprint(self.CERT_SHARED))
+
+        with self.subTest("dangling discovery_id row removed entirely"):
+            self.assertFalse(
+                discovery_certificate_model.objects.filter(uuid=self.dangling_row_uuid).exists()
+            )
+
+        with self.subTest("dangling-only content is never inserted as an orphan certificate"):
+            # The dangling row's content exists nowhere else, so the backfill (which
+            # only sources rows whose discovery still exists) must not create a
+            # certificate for it -- the upgrade leaves no immediately-orphaned rows.
+            self.assertEqual(
+                certificate_model.objects.filter(base64content=self.CERT_DANGLING).count(), 0
+            )
+            # Exactly the four distinct still-referenced contents survive as certificates.
+            self.assertEqual(certificate_model.objects.count(), 4)
+
+        with self.subTest("every surviving join row keeps its uuid/meta and gets a valid certificate"):
+            surviving_rows = list(discovery_certificate_model.objects.all())
+            surviving_uuids = {str(row.uuid) for row in surviving_rows}
+            expected_surviving_uuids = set(self.seeded_rows) - {self.dangling_row_uuid}
+            self.assertSetEqual(surviving_uuids, expected_surviving_uuids)
+
+            valid_cert_ids = set(certificate_model.objects.values_list("id", flat=True))
+            for row in surviving_rows:
+                seeded = self.seeded_rows[str(row.uuid)]
+                self.assertIn(row.certificate_id, valid_cert_ids)
+                self.assertEqual(row.meta, seeded["meta"])
+                self.assertEqual(row.discovery_id, seeded["discovery_id"])
+                linked_cert = certificate_model.objects.get(id=row.certificate_id)
+                self.assertEqual(linked_cert.base64content, seeded["base64content"])
+
+        with self.subTest("join-row counts for valid discoveries are preserved"):
+            self.assertEqual(
+                discovery_certificate_model.objects.filter(discovery_id=self.discovery_a_id).count(), 4
+            )
+            self.assertEqual(
+                discovery_certificate_model.objects.filter(discovery_id=self.discovery_b_id).count(), 2
+            )
+            self.assertEqual(discovery_certificate_model.objects.count(), 6)
+
+        with self.subTest("shared certificate is referenced by both discoveries"):
+            cert_shared = certificate_model.objects.get(base64content=self.CERT_SHARED)
+            shared_links = discovery_certificate_model.objects.filter(certificate_id=cert_shared.id)
+            self.assertEqual(shared_links.count(), 2)
+            self.assertSetEqual(
+                set(shared_links.values_list("discovery_id", flat=True)),
+                {self.discovery_a_id, self.discovery_b_id},
+            )
+
+        with self.subTest("cert duplicated within one discovery collapses but both links survive"):
+            cert_dup_one = certificate_model.objects.get(base64content=self.CERT_DUP_ONE)
+            dup_links = discovery_certificate_model.objects.filter(certificate_id=cert_dup_one.id)
+            self.assertEqual(dup_links.count(), 2)
+            self.assertTrue(all(link.discovery_id == self.discovery_a_id for link in dup_links))
+
+        with self.subTest("base64content column removed from discovery_certificate"):
+            with connection.cursor() as cursor:
+                columns = {
+                    col.name
+                    for col in connection.introspection.get_table_description(
+                        cursor, "discovery_certificate"
+                    )
+                }
+            self.assertNotIn("base64content", columns)
+
+        with self.subTest("schema shape: unique fingerprint, FKs, index, bigint discovery_id"):
+            with connection.cursor() as cursor:
+                cert_constraints = connection.introspection.get_constraints(cursor, "certificate")
+                self.assertTrue(
+                    any(
+                        c["unique"] and c["columns"] == ["fingerprint"]
+                        for c in cert_constraints.values()
+                    ),
+                    f"expected a unique constraint on certificate.fingerprint, got: {cert_constraints}",
+                )
+
+                dc_constraints = connection.introspection.get_constraints(
+                    cursor, "discovery_certificate"
+                )
+
+                fk_targets = {
+                    (c["foreign_key"][0], tuple(c["columns"]))
+                    for c in dc_constraints.values()
+                    if c.get("foreign_key")
+                }
+                self.assertIn(("certificate", ("certificate_id",)), fk_targets)
+                self.assertIn(("discovery_history", ("discovery_id",)), fk_targets)
+
+                self.assertTrue(
+                    any(
+                        c["index"] and c["columns"] == ["certificate_id"]
+                        for c in dc_constraints.values()
+                    ),
+                    f"expected an index on discovery_certificate.certificate_id, got: {dc_constraints}",
+                )
+
+                dc_columns = connection.introspection.get_table_description(
+                    cursor, "discovery_certificate"
+                )
+                discovery_id_col = next(c for c in dc_columns if c.name == "discovery_id")
+                # Postgres OID 20 == int8/bigint.
+                self.assertEqual(discovery_id_col.type_code, 20)

--- a/pyadcs_connector/PyADCSConnector/utils/certificate_fingerprint.py
+++ b/pyadcs_connector/PyADCSConnector/utils/certificate_fingerprint.py
@@ -1,0 +1,15 @@
+import hashlib
+
+
+def certificate_fingerprint(base64content: str) -> str:
+    """SHA-256 hex of the exact base64 certificate string (UTF-8), matching the SQL
+    encode(sha256(convert_to(base64content,'UTF8')),'hex') used by migration 0002.
+
+    Accepted limitation: the exact string is hashed, with no decoding or
+    normalization, so two byte-different base64 encodings of the same certificate
+    (different line wrapping, trailing whitespace) yield different fingerprints and
+    are stored as separate rows. This is deliberate -- it keeps Python and the
+    migration's SQL byte-identical and cannot fail on malformed base64 -- and costs
+    nothing in practice because ADCS returns each certificate in a stable encoding.
+    """
+    return hashlib.sha256(base64content.encode("utf-8")).hexdigest()

--- a/pyadcs_connector/PyADCSConnector/views/discovery_history.py
+++ b/pyadcs_connector/PyADCSConnector/views/discovery_history.py
@@ -6,7 +6,6 @@ from django.db import transaction
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
 
-from PyADCSConnector.models.discovery_certificate import DiscoveryCertificate
 from PyADCSConnector.models.discovery_history import DiscoveryHistory
 from PyADCSConnector.objects.discovery_history_request_dto import DiscoveryHistoryRequestDto
 from PyADCSConnector.services.discovery_history import create_discovery_history, get_discovery_history_data, \
@@ -40,9 +39,13 @@ def start_discovery(request, *args, **kwargs):
 def discovery_operations(request, uuid, *args, **kwargs):
     if request.method == "DELETE":
         try:
-            discovery_history = DiscoveryHistory.objects.get(uuid=uuid)
-            discovery_certificates = DiscoveryCertificate.objects.filter(discovery_id=discovery_history.id)
-            discovery_certificates.delete()
+            # select_for_update locks the row so a concurrent discovery
+            # persistence (which reads the same row under FOR UPDATE before
+            # adding join rows) cannot slip in a new DiscoveryCertificate
+            # after we've collected this discovery's rows for cascade delete.
+            discovery_history = DiscoveryHistory.objects.select_for_update().get(uuid=uuid)
+            # ORM cascade (DiscoveryCertificate.discovery FK, on_delete=CASCADE)
+            # clears join rows; shared Certificate rows are left for the cleanup sweep.
             discovery_history.delete()
             # return 204 no content
             return JsonResponse({}, status=204)

--- a/pyadcs_connector/pyadcs_connector/asgi.py
+++ b/pyadcs_connector/pyadcs_connector/asgi.py
@@ -14,3 +14,12 @@ from django.core.asgi import get_asgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pyadcs_connector.settings')
 
 application = get_asgi_application()
+
+# Started from the WSGI/ASGI entrypoints (see wsgi.py for the full notes on
+# `runserver` and gunicorn --preload), not from AppConfig.ready(), so the scheduler
+# runs only when the app is actually served -- never during `manage.py migrate` /
+# `manage.py test` / `manage.py check`. Starting it from both entrypoints is safe:
+# start_cleanup_scheduler() starts at most once.
+from PyADCSConnector.services.certificate_cleanup import start_cleanup_scheduler
+
+start_cleanup_scheduler()

--- a/pyadcs_connector/pyadcs_connector/settings.py
+++ b/pyadcs_connector/pyadcs_connector/settings.py
@@ -27,6 +27,18 @@ ADCS_ISSUE_POLLING_TIMEOUT = env("ADCS_ISSUE_POLLING_TIMEOUT", default=3000)
 # Prefix used for all database tables
 DATABASE_SCHEMA = env("DATABASE_SCHEMA", default="pyadcs")
 
+# Advisory lock key shared between discovery persistence (shared lock) and the
+# certificate cleanup sweep (exclusive lock), coordinating dangling-certificate
+# cleanup with in-flight discovery writes.
+CERTIFICATE_CLEANUP_LOCK_KEY = 4021900003
+
+# Scheduled orphan-certificate cleanup sweep (see PyADCSConnector.services.certificate_cleanup).
+CERTIFICATE_CLEANUP_ENABLED = env.bool("CERTIFICATE_CLEANUP_ENABLED", default=True)
+CERTIFICATE_CLEANUP_INTERVAL_SECONDS = env.int("CERTIFICATE_CLEANUP_INTERVAL_SECONDS", default=86400)
+# Rows deleted per transaction: the sweep releases its exclusive lock between
+# batches so a large backlog cannot stall discovery writes for its whole duration.
+CERTIFICATE_CLEANUP_BATCH_SIZE = env.int("CERTIFICATE_CLEANUP_BATCH_SIZE", default=1000)
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 

--- a/pyadcs_connector/pyadcs_connector/wsgi.py
+++ b/pyadcs_connector/pyadcs_connector/wsgi.py
@@ -14,3 +14,21 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pyadcs_connector.settings')
 
 application = get_wsgi_application()
+
+# Started from the WSGI/ASGI entrypoints (see also asgi.py), not from
+# AppConfig.ready(), so the scheduler runs only when the app is actually served --
+# never during `manage.py migrate` / `manage.py test` / `manage.py check`. Starting
+# it from both entrypoints is safe: start_cleanup_scheduler() starts at most once.
+#
+# Two consequences of starting it here:
+#   - `manage.py runserver` also imports this module, so a development server runs
+#     the sweep against its database too. Set CERTIFICATE_CLEANUP_ENABLED=false to
+#     turn it off there.
+#   - Do not run gunicorn with --preload: the app is then imported by the pre-fork
+#     master, so the thread starts there and is not inherited by the forked workers.
+#     Ownership of the sweep would move to the master process, outside the worker
+#     lifecycle that supervises it. The shipped docker/opt/pyadcs/entry.sh
+#     deliberately does not use --preload.
+from PyADCSConnector.services.certificate_cleanup import start_cleanup_scheduler
+
+start_cleanup_scheduler()


### PR DESCRIPTION
Discovery now stores certificate content once in a shared `certificate` table keyed by the SHA-256 fingerprint of the base64 content, with `discovery_certificate` reduced to a join that keeps its own `uuid` and `meta`. A scheduled background job periodically removes certificates that are no longer referenced by any discovery.

- New `certificate` and `certificate_cleanup_state` tables; `discovery_certificate` gains a `certificate` foreign key and its `discovery_id` becomes a real foreign key to `discovery_history`.
- Forward-only data migration (0002) deduplicates existing content, backfills the references, drops rows with a dangling discovery, and removes the old `base64content` column. Existing deployments upgrade transparently with no data loss and no manual steps.
- Discovery persistence performs WinRM collection outside the database transaction and takes a shared advisory lock; the cleanup sweep takes the matching exclusive lock and runs at most once per interval across workers.
- Discovery and authority API responses are unchanged.
- Cleanup is configurable via `CERTIFICATE_CLEANUP_ENABLED` and `CERTIFICATE_CLEANUP_INTERVAL_SECONDS`.
- Requires PostgreSQL 14+.
